### PR TITLE
[GATEWAY-2179] Add standalone AgentClient for streaming Agent API responses

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,4 +2,5 @@
 src/index.ts
 src/CustomClient.ts
 src/api/resources/_WrappedClients.ts
+src/agent/
 .github/workflows/ci.yml

--- a/src/agent/AgentClient.ts
+++ b/src/agent/AgentClient.ts
@@ -1,0 +1,122 @@
+import { parseSSEStream } from "./sse.js";
+import type { AgentMetadata, AgentResponseEvent, AgentRunInput } from "./types.js";
+
+const ENV_TOKEN = "TFY_API_KEY";
+
+export interface AgentClientOptions {
+    /** Base URL including tenant (e.g. "https://host/api/llm/truefoundry"). */
+    baseUrl: string;
+    /** API key for Bearer auth. Falls back to the TFY_API_KEY environment variable. */
+    apiKey?: string;
+    /** Default metadata headers sent with every request (e.g. TFY_ALPHA_ENABLE_PLANNING). */
+    metadata?: AgentMetadata;
+    /** Default timeout in seconds. */
+    timeoutInSeconds?: number;
+    /** Provide a custom fetch implementation. */
+    fetch?: typeof fetch;
+}
+
+export interface StreamOptions {
+    /** Abort signal to cancel the request. */
+    signal?: AbortSignal;
+    /** Per-request metadata merged on top of client-level defaults. */
+    metadata?: AgentMetadata;
+}
+
+export class AgentClient {
+    private readonly baseUrl: string;
+    private readonly apiKey: string | undefined;
+    private readonly defaultMetadata: AgentMetadata;
+    private readonly timeoutMs: number | undefined;
+    private readonly fetchFn: typeof fetch | undefined;
+
+    constructor(options: AgentClientOptions) {
+        this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+        this.apiKey = options.apiKey;
+        this.defaultMetadata = options.metadata ?? {};
+        this.timeoutMs = options.timeoutInSeconds ? options.timeoutInSeconds * 1000 : undefined;
+        this.fetchFn = options.fetch;
+    }
+
+    private resolveApiKey(): string {
+        const key = this.apiKey ?? (typeof process !== "undefined" ? process.env?.[ENV_TOKEN] : undefined);
+        if (!key) {
+            throw new AgentClientError(
+                `No API key provided. Pass apiKey in AgentClientOptions or set the ${ENV_TOKEN} environment variable.`,
+                0,
+            );
+        }
+        return key;
+    }
+
+    /**
+     * Send an agent run request and stream back response events via SSE.
+     *
+     * @param input - Either a NamedAgentRunInput (agent_name) or InlineAgentRunInput (model + config).
+     * @param options - Optional abort signal and per-request metadata overrides.
+     * @returns An async generator yielding AgentResponseEvent objects as they arrive.
+     */
+    async *stream(input: AgentRunInput, options?: StreamOptions): AsyncGenerator<AgentResponseEvent> {
+        const apiKey = this.resolveApiKey();
+        const metadata = { ...this.defaultMetadata, ...options?.metadata };
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+        };
+
+        if (Object.keys(metadata).length > 0) {
+            headers["x-tfy-metadata"] = JSON.stringify(metadata);
+        }
+
+        const fetchFn = this.fetchFn ?? globalThis.fetch;
+
+        let signal = options?.signal;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        if (!signal && this.timeoutMs) {
+            const controller = new AbortController();
+            signal = controller.signal;
+            timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+        }
+
+        try {
+            const response = await fetchFn(`${this.baseUrl}/agent/responses`, {
+                method: "POST",
+                headers,
+                body: JSON.stringify(input),
+                signal,
+            });
+
+            if (!response.ok) {
+                const body = await response.text().catch(() => "");
+                throw new AgentClientError(
+                    `Agent API returned ${response.status}: ${body}`,
+                    response.status,
+                    body,
+                );
+            }
+
+            if (!response.body) {
+                throw new AgentClientError("Response body is empty", response.status);
+            }
+
+            yield* parseSSEStream<AgentResponseEvent>(response.body);
+        } finally {
+            if (timeoutId !== undefined) {
+                clearTimeout(timeoutId);
+            }
+        }
+    }
+}
+
+export class AgentClientError extends Error {
+    public readonly status: number;
+    public readonly responseBody?: string;
+
+    constructor(message: string, status: number, responseBody?: string) {
+        super(message);
+        this.name = "AgentClientError";
+        this.status = status;
+        this.responseBody = responseBody;
+    }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,10 +1,9 @@
-export * as TrueFoundry from "./api";
-export { TrueFoundryError, TrueFoundryTimeoutError } from "./errors";
-export { TrueFoundryClient } from "./CustomClient";
+export { AgentClient, AgentClientError } from "./AgentClient.js";
+export type { AgentClientOptions, StreamOptions } from "./AgentClient.js";
 
-export { AgentClient, AgentClientError, isInlineAgentRunInput, isNamedAgentRunInput } from "./agent/index";
+export { isInlineAgentRunInput, isNamedAgentRunInput } from "./types.js";
+
 export type {
-    AgentClientOptions,
     AgentAssistantMessage,
     AgentExecutionCreated,
     AgentExecutionDone,
@@ -21,12 +20,24 @@ export type {
     AgentSandboxCreated,
     AgentToolResponseDelta,
     CompletionUsage,
+    ExtendedToolCall,
+    ExtendedToolCallFunction,
     FinishReason,
     InlineAgentRunInput,
+    MCPInitializationInfo,
+    MCPOAuthLoginUrl,
     MCPServerRequest,
+    MCPToolCallInfo,
+    MCPToolSettings,
     ModelParams,
     NamedAgentRunInput,
+    RedactedThinkingBlock,
     ResponseCreated,
     ResponseError,
-    StreamOptions,
-} from "./agent/index";
+    SandboxConfig,
+    SubAgentRequest,
+    ThinkingBlock,
+    ToolCallDelta,
+    ToolCallFunction,
+    UserMessageInput,
+} from "./types.js";

--- a/src/agent/sse.ts
+++ b/src/agent/sse.ts
@@ -1,0 +1,52 @@
+/**
+ * Minimal SSE parser — zero external dependencies.
+ *
+ * Consumes a ReadableStream<Uint8Array> (from fetch response.body) and yields
+ * parsed JSON objects from `data:` lines. The server writes each event as:
+ *
+ *   data: <JSON>\n\n
+ */
+export async function* parseSSEStream<T = unknown>(stream: ReadableStream): AsyncGenerator<T> {
+    const decoder = new TextDecoder();
+    const reader = stream.getReader();
+    let buffer = "";
+
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += typeof value === "string" ? value : decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop()!;
+
+            for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed || !trimmed.startsWith("data:")) continue;
+
+                const jsonStr = trimmed.slice("data:".length).trim();
+                if (!jsonStr) continue;
+
+                try {
+                    yield JSON.parse(jsonStr) as T;
+                } catch {
+                    // Skip malformed JSON payloads.
+                }
+            }
+        }
+
+        if (buffer.trim().startsWith("data:")) {
+            const jsonStr = buffer.trim().slice("data:".length).trim();
+            if (jsonStr) {
+                try {
+                    yield JSON.parse(jsonStr) as T;
+                } catch {
+                    // ignore
+                }
+            }
+        }
+    } finally {
+        await reader.cancel();
+        reader.releaseLock();
+    }
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,0 +1,280 @@
+/**
+ * Self-contained type definitions for the TrueFoundry Agent API.
+ *
+ * These describe the JSON wire format only — no external dependencies (openai, zod, etc.).
+ * Kept in sync with tfy-llm-gateway/src/agent/Types.ts and schemas.ts.
+ */
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+export interface ModelParams {
+    max_tokens?: number;
+    temperature?: number;
+    top_p?: number;
+    top_k?: number;
+    parallel_tool_calls?: boolean;
+    reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high";
+    [key: string]: unknown;
+}
+
+export interface MCPToolSettings {
+    name: string;
+    eager?: true;
+}
+
+export interface MCPServerRequest {
+    name: string;
+    headers?: Record<string, string>;
+    enable_all_tools?: boolean;
+    tools?: MCPToolSettings[];
+    deferred?: boolean;
+}
+
+export interface SubAgentRequest {
+    name: string;
+}
+
+export interface UserMessageInput {
+    role: "user";
+    content: string;
+}
+
+export interface SandboxConfig {
+    enabled: boolean;
+}
+
+interface BaseAgentRunInput {
+    input?: unknown[];
+    previous_response_id?: string;
+    store?: boolean;
+    variables?: Record<string, string>;
+}
+
+export interface NamedAgentRunInput extends BaseAgentRunInput {
+    agent_name: string;
+}
+
+export interface InlineAgentRunInput extends BaseAgentRunInput {
+    model: string;
+    instruction?: string;
+    messages?: UserMessageInput[];
+    mcp_servers?: MCPServerRequest[];
+    sub_agents?: SubAgentRequest[];
+    model_params?: ModelParams;
+    response_format?: unknown;
+    iteration_limit?: number;
+    sandbox?: SandboxConfig;
+}
+
+export type AgentRunInput = NamedAgentRunInput | InlineAgentRunInput;
+
+export function isNamedAgentRunInput(input: AgentRunInput): input is NamedAgentRunInput {
+    return "agent_name" in input && typeof (input as NamedAgentRunInput).agent_name === "string";
+}
+
+export function isInlineAgentRunInput(input: AgentRunInput): input is InlineAgentRunInput {
+    return "model" in input;
+}
+
+// ---------------------------------------------------------------------------
+// Shared / nested types used by response events
+// ---------------------------------------------------------------------------
+
+export type FinishReason = "stop" | "length" | "tool_calls" | "content_filter" | "function_call" | null;
+
+export interface AgentParent {
+    toolCallId: string;
+    executionId: string;
+}
+
+export interface AgentInfo {
+    type: "agent-defined";
+    name: string;
+    input: string;
+}
+
+export interface CompletionUsage {
+    completion_tokens: number;
+    prompt_tokens: number;
+    total_tokens: number;
+}
+
+export interface MCPToolCallInfo {
+    mcp_server_id: string;
+    mcp_server_name: string;
+    original_tool_name: string;
+}
+
+export interface ToolCallFunction {
+    name?: string;
+    arguments?: string;
+    thought_signature?: string;
+    tool_info?: MCPToolCallInfo;
+}
+
+export interface ToolCallDelta {
+    index: number;
+    id?: string;
+    type?: "function";
+    function?: ToolCallFunction;
+    provider_specific_fields?: { thought_signature?: string };
+}
+
+export interface ThinkingBlock {
+    type: "thinking";
+    thinking: string;
+    signature?: string;
+}
+
+export interface RedactedThinkingBlock {
+    type: "redacted_thinking";
+    data: string;
+}
+
+export interface ExtendedToolCallFunction {
+    name: string;
+    arguments: string;
+    thought_signature?: string;
+    tool_info?: MCPToolCallInfo;
+}
+
+export interface ExtendedToolCall {
+    id: string;
+    type: "function";
+    function: ExtendedToolCallFunction;
+    provider_specific_fields?: { thought_signature?: string };
+}
+
+export interface MCPOAuthLoginUrl {
+    mcp_server_id: string;
+    mcp_server_name: string;
+    url: string;
+}
+
+export interface MCPInitializationInfo {
+    mcp_server_id: string;
+    mcp_server_name: string;
+    sessionId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Response event types — each has a unique `type` discriminator
+// ---------------------------------------------------------------------------
+
+export interface ResponseCreated {
+    type: "response.created";
+    responseId: string;
+    createdAt: string;
+}
+
+export interface ResponseError {
+    type: "response.error";
+    message: string;
+}
+
+export interface AgentExecutionCreated {
+    type: "agent.created";
+    executionId: string;
+    parent: AgentParent;
+    agentInfo: AgentInfo;
+    createdAt?: string;
+}
+
+export interface AgentExecutionDone {
+    type: "agent.done";
+    executionId: string;
+    output: AgentAssistantMessage;
+    parent: AgentParent | undefined;
+}
+
+export interface AgentExecutionError {
+    type: "agent.error";
+    executionId: string;
+    parent: AgentParent | undefined;
+    message: string;
+    output?: AgentAssistantMessage;
+}
+
+/**
+ * Streaming delta for assistant LLM messages.
+ * Shares `type: "agent.message"` with tool responses — distinguished by `role`.
+ */
+export interface AgentLLMMessageDelta {
+    type: "agent.message";
+    executionId: string;
+    role?: "assistant";
+    content?: string | null;
+    tool_calls?: ToolCallDelta[];
+    thinking_blocks?: Array<ThinkingBlock | RedactedThinkingBlock>;
+    reasoning_content?: string;
+    createdAt?: string;
+    finishReason?: FinishReason;
+}
+
+/** Tool execution result streamed back. */
+export interface AgentToolResponseDelta {
+    type: "agent.message";
+    executionId: string;
+    role: "tool";
+    content: string;
+    tool_call_id: string;
+}
+
+/** Completed assistant message (used in `agent.done` output). */
+export interface AgentAssistantMessage {
+    type: "agent.message";
+    executionId: string;
+    role: "assistant";
+    content?: string | null;
+    tool_calls?: ExtendedToolCall[];
+    thinking_blocks?: Array<ThinkingBlock | RedactedThinkingBlock>;
+    finishReason: FinishReason;
+    createdAt?: number;
+}
+
+export interface AgentMCPAuthRequired {
+    type: "mcp.auth_required";
+    executionId: string;
+    oauth_login_urls: MCPOAuthLoginUrl[];
+}
+
+export interface AgentMCPInitialize {
+    type: "mcp.initialize";
+    executionId: string;
+    content: MCPInitializationInfo[];
+}
+
+export interface AgentSandboxCreated {
+    type: "sandbox.created";
+    executionId: string;
+    sandboxId: string;
+}
+
+export interface AgentExecutionOverwriteContext {
+    type: "agent.context.overwrite";
+    executionId: string;
+    reason: "compaction";
+    context: unknown[];
+    currentContextUsage: CompletionUsage;
+}
+
+// ---------------------------------------------------------------------------
+// Union of all SSE events the client may receive
+// ---------------------------------------------------------------------------
+
+export type AgentResponseEvent =
+    | AgentLLMMessageDelta
+    | AgentToolResponseDelta
+    | AgentExecutionError
+    | AgentExecutionDone
+    | AgentExecutionCreated
+    | AgentMCPAuthRequired
+    | AgentMCPInitialize
+    | AgentSandboxCreated
+    | AgentExecutionOverwriteContext
+    | ResponseCreated
+    | ResponseError;
+
+export type AgentMetadata = Record<string, string>;

--- a/tests/unit/agent/AgentClient.test.ts
+++ b/tests/unit/agent/AgentClient.test.ts
@@ -1,0 +1,247 @@
+import { AgentClient, AgentClientError } from "../../../src/agent/AgentClient";
+
+function createMockFetch(status: number, body: string, headers?: Record<string, string>) {
+    const encoder = new TextEncoder();
+    return vi.fn().mockResolvedValue(
+        new Response(
+            new ReadableStream({
+                start(controller) {
+                    controller.enqueue(encoder.encode(body));
+                    controller.close();
+                },
+            }),
+            { status, headers },
+        ),
+    );
+}
+
+function createSSEBody(events: object[]): string {
+    return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+}
+
+describe("AgentClient", () => {
+    describe("constructor", () => {
+        it("should strip trailing slashes from baseUrl", () => {
+            const client = new AgentClient({ baseUrl: "https://host/api/llm/tenant///", apiKey: "key" });
+            // Verify by making a request and checking the URL
+            const mockFetch = createMockFetch(200, createSSEBody([{ type: "agent.done" }]));
+            const clientWithFetch = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant///",
+                apiKey: "key",
+                fetch: mockFetch,
+            });
+
+            // Consume the stream to trigger the fetch
+            (async () => {
+                for await (const _ of clientWithFetch.stream({ agent_name: "test", input: [] })) {
+                    // consume
+                }
+            })().then(() => {
+                expect(mockFetch).toHaveBeenCalledWith(
+                    "https://host/api/llm/tenant/agent/responses",
+                    expect.anything(),
+                );
+            });
+        });
+    });
+
+    describe("stream", () => {
+        it("should send correct request headers and body", async () => {
+            const mockFetch = createMockFetch(200, createSSEBody([{ type: "agent.done" }]));
+
+            const client = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant",
+                apiKey: "test-key",
+                metadata: { TFY_ALPHA_ENABLE_PLANNING: "true" },
+                fetch: mockFetch,
+            });
+
+            for await (const _ of client.stream({ agent_name: "my-agent", input: [] })) {
+                // consume
+            }
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "https://host/api/llm/tenant/agent/responses",
+                expect.objectContaining({
+                    method: "POST",
+                    body: JSON.stringify({ agent_name: "my-agent", input: [] }),
+                }),
+            );
+
+            const callArgs = mockFetch.mock.calls[0][1];
+            expect(callArgs.headers["Authorization"]).toBe("Bearer test-key");
+            expect(callArgs.headers["Content-Type"]).toBe("application/json");
+            expect(JSON.parse(callArgs.headers["x-tfy-metadata"])).toEqual({
+                TFY_ALPHA_ENABLE_PLANNING: "true",
+            });
+        });
+
+        it("should not send x-tfy-metadata when metadata is empty", async () => {
+            const mockFetch = createMockFetch(200, createSSEBody([{ type: "agent.done" }]));
+
+            const client = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant",
+                apiKey: "key",
+                fetch: mockFetch,
+            });
+
+            for await (const _ of client.stream({ agent_name: "test", input: [] })) {
+                // consume
+            }
+
+            const callArgs = mockFetch.mock.calls[0][1];
+            expect(callArgs.headers["x-tfy-metadata"]).toBeUndefined();
+        });
+
+        it("should yield parsed SSE events", async () => {
+            const sseEvents = [
+                { type: "response.created", responseId: "abc" },
+                { type: "agent.message", content: "hello", role: "assistant" },
+                { type: "agent.done", executionId: "exec-1" },
+            ];
+            const mockFetch = createMockFetch(200, createSSEBody(sseEvents));
+
+            const client = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant",
+                apiKey: "key",
+                fetch: mockFetch,
+            });
+
+            const received: object[] = [];
+            for await (const event of client.stream({ agent_name: "test", input: [] })) {
+                received.push(event);
+            }
+
+            expect(received).toEqual(sseEvents);
+        });
+
+        it("should throw AgentClientError on non-200 response", async () => {
+            const mockFetch = vi.fn().mockResolvedValue(
+                new Response('{"error":"unauthorized"}', { status: 401 }),
+            );
+
+            const client = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant",
+                apiKey: "bad-key",
+                fetch: mockFetch,
+            });
+
+            let caught: unknown;
+            try {
+                for await (const _ of client.stream({ agent_name: "test", input: [] })) {
+                    // consume
+                }
+            } catch (err) {
+                caught = err;
+            }
+
+            expect(caught).toBeInstanceOf(AgentClientError);
+            expect((caught as AgentClientError).status).toBe(401);
+            expect((caught as AgentClientError).responseBody).toBe('{"error":"unauthorized"}');
+        });
+
+        it("should throw AgentClientError when response body is null", async () => {
+            const mockFetch = vi.fn().mockResolvedValue(
+                new Response(null, { status: 200 }),
+            );
+
+            const client = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant",
+                apiKey: "key",
+                fetch: mockFetch,
+            });
+
+            await expect(async () => {
+                for await (const _ of client.stream({ agent_name: "test", input: [] })) {
+                    // consume
+                }
+            }).rejects.toThrow("Response body is empty");
+        });
+
+        it("should merge per-request metadata with defaults", async () => {
+            const mockFetch = createMockFetch(200, createSSEBody([{ type: "agent.done" }]));
+
+            const client = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant",
+                apiKey: "key",
+                metadata: { key1: "default" },
+                fetch: mockFetch,
+            });
+
+            for await (const _ of client.stream(
+                { agent_name: "test", input: [] },
+                { metadata: { key2: "override" } },
+            )) {
+                // consume
+            }
+
+            const callArgs = mockFetch.mock.calls[0][1];
+            expect(JSON.parse(callArgs.headers["x-tfy-metadata"])).toEqual({
+                key1: "default",
+                key2: "override",
+            });
+        });
+
+        it("should pass abort signal to fetch", async () => {
+            const mockFetch = createMockFetch(200, createSSEBody([{ type: "agent.done" }]));
+
+            const client = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant",
+                apiKey: "key",
+                fetch: mockFetch,
+            });
+
+            const controller = new AbortController();
+            for await (const _ of client.stream(
+                { agent_name: "test", input: [] },
+                { signal: controller.signal },
+            )) {
+                // consume
+            }
+
+            const callArgs = mockFetch.mock.calls[0][1];
+            expect(callArgs.signal).toBe(controller.signal);
+        });
+    });
+
+    describe("resolveApiKey", () => {
+        it("should throw when no apiKey and no env var", async () => {
+            const originalEnv = process.env.TFY_API_KEY;
+            delete process.env.TFY_API_KEY;
+
+            const client = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant",
+                fetch: vi.fn(),
+            });
+
+            await expect(async () => {
+                for await (const _ of client.stream({ agent_name: "test", input: [] })) {
+                    // consume
+                }
+            }).rejects.toThrow("No API key provided");
+
+            process.env.TFY_API_KEY = originalEnv;
+        });
+
+        it("should fall back to TFY_API_KEY env var", async () => {
+            const originalEnv = process.env.TFY_API_KEY;
+            process.env.TFY_API_KEY = "env-key";
+
+            const mockFetch = createMockFetch(200, createSSEBody([{ type: "agent.done" }]));
+
+            const client = new AgentClient({
+                baseUrl: "https://host/api/llm/tenant",
+                fetch: mockFetch,
+            });
+
+            for await (const _ of client.stream({ agent_name: "test", input: [] })) {
+                // consume
+            }
+
+            const callArgs = mockFetch.mock.calls[0][1];
+            expect(callArgs.headers["Authorization"]).toBe("Bearer env-key");
+
+            process.env.TFY_API_KEY = originalEnv;
+        });
+    });
+});

--- a/tests/unit/agent/sse.test.ts
+++ b/tests/unit/agent/sse.test.ts
@@ -1,0 +1,97 @@
+import { parseSSEStream } from "../../../src/agent/sse";
+
+function createSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    return new ReadableStream({
+        start(controller) {
+            for (const chunk of chunks) {
+                controller.enqueue(encoder.encode(chunk));
+            }
+            controller.close();
+        },
+    });
+}
+
+async function collectEvents<T>(stream: ReadableStream): Promise<T[]> {
+    const events: T[] = [];
+    for await (const event of parseSSEStream<T>(stream)) {
+        events.push(event);
+    }
+    return events;
+}
+
+describe("parseSSEStream", () => {
+    it("should parse single SSE event", async () => {
+        const stream = createSSEStream(['data: {"type":"agent.done"}\n\n']);
+        const events = await collectEvents(stream);
+        expect(events).toEqual([{ type: "agent.done" }]);
+    });
+
+    it("should parse multiple SSE events", async () => {
+        const stream = createSSEStream([
+            'data: {"type":"response.created","responseId":"abc"}\n\n',
+            'data: {"type":"agent.message","content":"hello"}\n\n',
+            'data: {"type":"agent.done"}\n\n',
+        ]);
+        const events = await collectEvents(stream);
+        expect(events).toHaveLength(3);
+        expect(events[0]).toEqual({ type: "response.created", responseId: "abc" });
+        expect(events[1]).toEqual({ type: "agent.message", content: "hello" });
+        expect(events[2]).toEqual({ type: "agent.done" });
+    });
+
+    it("should handle events split across chunks", async () => {
+        const stream = createSSEStream([
+            'data: {"type":"age',
+            'nt.done"}\n\n',
+        ]);
+        const events = await collectEvents(stream);
+        expect(events).toEqual([{ type: "agent.done" }]);
+    });
+
+    it("should handle multiple events in a single chunk", async () => {
+        const stream = createSSEStream([
+            'data: {"a":1}\n\ndata: {"b":2}\n\n',
+        ]);
+        const events = await collectEvents(stream);
+        expect(events).toEqual([{ a: 1 }, { b: 2 }]);
+    });
+
+    it("should skip empty data lines", async () => {
+        const stream = createSSEStream(["data: \n\n", 'data: {"type":"ok"}\n\n']);
+        const events = await collectEvents(stream);
+        expect(events).toEqual([{ type: "ok" }]);
+    });
+
+    it("should skip non-data lines (comments, event, id)", async () => {
+        const stream = createSSEStream([
+            ": this is a comment\n",
+            "event: message\n",
+            "id: 123\n",
+            'data: {"type":"ok"}\n\n',
+        ]);
+        const events = await collectEvents(stream);
+        expect(events).toEqual([{ type: "ok" }]);
+    });
+
+    it("should skip malformed JSON without crashing", async () => {
+        const stream = createSSEStream([
+            "data: not-json\n\n",
+            'data: {"type":"ok"}\n\n',
+        ]);
+        const events = await collectEvents(stream);
+        expect(events).toEqual([{ type: "ok" }]);
+    });
+
+    it("should handle empty stream", async () => {
+        const stream = createSSEStream([]);
+        const events = await collectEvents(stream);
+        expect(events).toEqual([]);
+    });
+
+    it("should handle trailing data without newline", async () => {
+        const stream = createSSEStream(['data: {"trailing":true}']);
+        const events = await collectEvents(stream);
+        expect(events).toEqual([{ trailing: true }]);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new streaming client code that handles Bearer auth headers, timeouts, and SSE parsing; bugs here could break agent response streaming or cause request hangs/timeouts. Changes are additive and covered by unit tests, but touch network/auth-related behavior.
> 
> **Overview**
> Adds a new standalone `AgentClient` for the Agent API that posts run input to `POST /agent/responses` and streams back typed `AgentResponseEvent` objects via SSE, with support for default/per-request metadata headers, abort signals, and optional timeouts (plus env var fallback for `TFY_API_KEY`).
> 
> Introduces a minimal dependency-free SSE parser (`parseSSEStream`) and a self-contained set of Agent API wire-format types, exports the new API from `src/index.ts`, and adds unit tests covering header construction, metadata merging, SSE parsing, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070c9cc8299ab6e9fe6467fbc1c657482f6eafab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->